### PR TITLE
Remove condition lists

### DIFF
--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -9,9 +9,9 @@ namespace command {
 
 Command::Command(
     std::vector<std::shared_ptr<action::ActionInterface>> actions,
-    std::vector<std::shared_ptr<Condition>> conditions,
+    command::ExprPtr condition,
     std::vector<event::EventType> events)
-    : actions(actions), conditions(conditions), events(events) {
+    : actions(actions), condition(condition), events(events), hs(nullptr) {
     // if not defined on any events, should be defined on the default event
     if(this->events.empty()) {
         this->events = event::getDefaultEventTypes();
@@ -89,8 +89,6 @@ void ActionGroup::action([[maybe_unused]] std::ostream* o) {
     }
 }
 } // namespace action
-
-bool Condition::check() { return hs && condition && bool(condition->eval(hs)); }
 
 void Watch::update() {
     std::optional<types::UnsignedInteger> current = readCurrentValue();

--- a/src/ishell/parser/parser.cpp
+++ b/src/ishell/parser/parser.cpp
@@ -76,24 +76,17 @@ Parser::Command_ptr Parser::parse_action_command() {
     auto event_list = parse_on_statement();
 
     actions = make_action_group(actions);
-    // if no condition (ie a nullptr), make condition_list empty
-    auto condition_list =
-        condition ? (std::initializer_list<Condition_ptr>){condition}
-                  : (std::initializer_list<Condition_ptr>());
 
-    return std::make_shared<command::Command>(
-        actions,
-        condition_list,
-        event_list);
+    return std::make_shared<command::Command>(actions, condition, event_list);
 }
-Parser::Condition_ptr Parser::parse_if_statement() {
+command::ExprPtr Parser::parse_if_statement() {
     common::debug::log(
         common::debug::DebugType::PARSER,
         "parse_if_statement()\n");
     if(lexer.peek().token_type == TokenType::IF) {
         expect(TokenType::IF);
         auto cond_expr = parse_expr();
-        return std::make_shared<command::Condition>(cond_expr);
+        return cond_expr;
     }
     return nullptr;
 }

--- a/src/ishell/parser/parser.h
+++ b/src/ishell/parser/parser.h
@@ -25,7 +25,6 @@ class Parser {
     using Control_ptr = std::shared_ptr<command::ControlBase>;
     using Watch_ptr = std::shared_ptr<command::Watch>;
     using Command_ptr = std::shared_ptr<command::Command>;
-    using Condition_ptr = std::shared_ptr<command::Condition>;
     using Action_ptr = std::shared_ptr<command::action::ActionInterface>;
 
   public:
@@ -53,7 +52,7 @@ class Parser {
     Control_ptr parse_control();
     Watch_ptr parse_watch_command();
     Command_ptr parse_action_command();
-    Condition_ptr parse_if_statement();
+    command::ExprPtr parse_if_statement();
     std::vector<event::EventType> parse_on_statement();
     std::vector<Action_ptr> parse_action_list();
     std::vector<event::EventType> parse_event_list();


### PR DESCRIPTION
Since conditions are now just an expression, it seems silly to keep around a whole vector of them, with virtual inheritance no less. A lot of overhead. This removes them and just uses an expr.

closes #42 