### PR TITLE
Add Instruction builder

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -25,6 +25,7 @@ YACC=/usr/bin/bison
 LEX=/usr/bin/flex
 AR=/usr/bin/ar
 RANLIB=/usr/bin/ranlib
+PYTHON3=/usr/bin/python3
 else ifeq ($(OS),Darwin)
 CC=/usr/local/opt/llvm/bin/clang
 CXX:=$(CC)
@@ -33,6 +34,7 @@ YACC=/usr/local/opt/bison/bin/bison
 LEX=/usr/local/opt/flex/bin/flex
 AR=/usr/local/opt/llvm/bin/llvm-ar
 RANLIB=/usr/local/opt/llvm/bin/llvm-ranlib
+PYTHON3=/usr/bin/python3
 else
 $(error Unsupported build on $(OS))
 endif
@@ -67,7 +69,7 @@ $(eval $(call _generate_verbose_call,$1))
 endef
 
 map = $(foreach a,$(2),$(call $(1),$(a)))
-$(call map,generate_verbose_call,CC CXX LD YACC LEX AR RANLIB)
+$(call map,generate_verbose_call,CC CXX LD YACC LEX AR RANLIB PYTHON3)
 
 COMPILE_FLAGS=
 LINK_FLAGS=

--- a/options.mk
+++ b/options.mk
@@ -72,9 +72,11 @@ $(call map,generate_verbose_call,CC CXX LD YACC LEX AR RANLIB)
 COMPILE_FLAGS=
 LINK_FLAGS=
 COMPILE_FLAGS+= -Wno-comment
+COMPILE_FLAGS+= -flto
+LINK_FLAGS+= -flto
 
 ifeq ($(DEBUG),1)
-COMPILE_FLAGS+= -DDEBUG=1 -g -O0 
+COMPILE_FLAGS+= -DDEBUG=1 -g -O0 -fstandalone-debug
 LINK_FLAGS+= -g
 else
 COMPILE_FLAGS+= -O3

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -3,6 +3,7 @@
 #include "color/color.h"
 #include "common/debug.h"
 #include "common/format.h"
+#include "hart/isa/inst-execute.h"
 #include "hart/isa/inst.h"
 
 namespace command {

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -11,5 +11,11 @@ std::string toupper(std::string str) {
     });
     return str;
 }
+std::string tolower(std::string str) {
+    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) {
+        return std::tolower(c);
+    });
+    return str;
+}
 } // namespace utils
 } // namespace common

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -5,6 +5,7 @@
 namespace common {
 namespace utils {
 extern std::string toupper(std::string str);
-}
+extern std::string tolower(std::string str);
+} // namespace utils
 } // namespace common
 #endif

--- a/src/dependencies.mk
+++ b/src/dependencies.mk
@@ -11,11 +11,12 @@ trace= hart
 color= hart
 zircon= hart command ishell elf mem trace event color common
 zircon-wasm= hart command ishell elf mem trace event color common
+inst-builder= hart common
 
 define make_depen
 $(eval $1: $($1))
 endef
 map = $(foreach a,$(2),$(call $(1),$(a)))
 define make_prereqs
-$(call map,make_depen,hart mem elf trace zircon zircon-wasm color event command ishell common)
+$(call map,make_depen,hart mem elf trace zircon zircon-wasm color event command ishell common inst-builder)
 endef

--- a/src/hart/Makefile
+++ b/src/hart/Makefile
@@ -7,6 +7,6 @@ TARGET_DEPENDS=$(GEN_DIRECTORY)generated-definition/
 
 $(TARGET_DEPENDS):
 	@mkdir -p $@
-	$(AT)python3 $(SRC_PATH)generate-includes.py $(OUT_OF_TREE_INST) >$@instructions.inc
-	$(AT)python3 $(SRC_PATH)generate-includes.py $(OUT_OF_TREE_REG) >$@registers.inc
-	$(AT)python3 $(SRC_PATH)generate-includes.py $(OUT_OF_TREE_SYSCALL) >$@syscalls.inc
+	$(PYTHON3) $(SRC_PATH)generate-includes.py $(OUT_OF_TREE_INST) >$@instructions.inc
+	$(PYTHON3) $(SRC_PATH)generate-includes.py $(OUT_OF_TREE_REG) >$@registers.inc
+	$(PYTHON3) $(SRC_PATH)generate-includes.py $(OUT_OF_TREE_SYSCALL) >$@syscalls.inc

--- a/src/hart/generate-includes.py
+++ b/src/hart/generate-includes.py
@@ -1,5 +1,7 @@
 import sys
+
 files = sys.argv[1:]
 for f in files:
-    with open(f, 'r') as fd:
+    with open(f, "r") as fd:
+        print(f'#line 0 "{f}"')
         print(fd.read())

--- a/src/hart/hart.cpp
+++ b/src/hart/hart.cpp
@@ -1,6 +1,7 @@
 #include "hart.h"
 
 #include "event/event.h"
+#include "isa/inst-execute.h"
 #include "isa/inst.h"
 #include "isa/instruction_match.h"
 #include "isa/rf.h"

--- a/src/hart/hartstate.cpp
+++ b/src/hart/hartstate.cpp
@@ -10,8 +10,8 @@ types::InstructionWord HartState::getInstWord() const {
 HartState::HartState(std::shared_ptr<mem::MemoryImage> m)
     : rf_(std::make_unique<isa::rf::RegisterFile>()), memories_(),
       execution_state(ExecutionState::STOPPED) {
-        // insert memory image for address space 0
-        this->memories_.insert_or_assign(0, m);
-      }
+    // insert memory image for address space 0
+    this->memories_.insert_or_assign(0, m);
+}
 
 } // namespace hart

--- a/src/hart/hartstate.h
+++ b/src/hart/hartstate.h
@@ -93,7 +93,9 @@ class HartState {
 
         auto addrSpace = nextAddressSpace;
         nextAddressSpace++;
-        memories_.insert_or_assign(addrSpace, std::make_shared<mem::MemoryImage>());
+        memories_.insert_or_assign(
+            addrSpace,
+            std::make_shared<mem::MemoryImage>());
         return addrSpace;
     }
 

--- a/src/hart/isa/defs/registers.inc
+++ b/src/hart/isa/defs/registers.inc
@@ -14,7 +14,6 @@
         #nice_name,                                                            \
         rd_only)
 
-
 /*out of tree registers take precedence over ones defined here*/
 /*this allows an application to override existing ones*/
 #include "generated-definition/registers.inc"

--- a/src/hart/isa/inst-execute.cpp
+++ b/src/hart/isa/inst-execute.cpp
@@ -1,0 +1,70 @@
+#include "inst-execute.h"
+
+#include "hart/hart.h"
+
+#include <sstream>
+
+#include "instruction_match.h"
+
+namespace isa {
+namespace inst {
+
+namespace internal {
+extern void executeInstruction(uint32_t bits, hart::HartState& hs);
+extern std::string disassemble(uint32_t bits, uint32_t pc, bool color);
+
+extern std::string colorReset(bool doColor);
+extern std::string colorError(bool doColor);
+extern std::string colorOpcode(bool doColor);
+extern std::string colorReg(bool doColor);
+extern std::string colorNumber(bool doColor);
+
+} // namespace internal
+
+void executeInstruction(uint32_t bits, hart::HartState& hs) {
+    Opcode op = decodeInstruction(bits);
+    switch(op) {
+        default: break;
+    }
+    internal::executeInstruction(bits, hs);
+}
+
+std::string disassemble(uint32_t bits, uint32_t pc, bool color) {
+    Opcode op = decodeInstruction(bits);
+    switch(op) {
+        default: break;
+        case Opcode::rv32i_auipc: {
+            std::stringstream ss;
+            ss << internal::colorOpcode(color) << Opcode::getNiceName(op)
+               << internal::colorReset(color) << " "
+               << internal::colorReg(color) << "x" << instruction::getRd(bits)
+               << internal::colorReset(color) << ", "
+               << internal::colorNumber(color) << "0x" << std::hex
+               << (instruction::getUTypeImm(bits) >> 12)
+               << internal::colorReset(color);
+            return ss.str();
+        }
+        case Opcode::rv32i_lb:
+        case Opcode::rv32i_lh:
+        case Opcode::rv32i_lw:
+        case Opcode::rv32i_lbu:
+        case Opcode::rv32i_lhu:
+        case Opcode::rv64i_lwu:
+        case Opcode::rv64i_ld: {
+            std::stringstream ss;
+            ss << internal::colorOpcode(color) << Opcode::getNiceName(op)
+               << internal::colorReset(color) << " "
+               << internal::colorReg(color) << "x" << instruction::getRd(bits)
+               << internal::colorReset(color) << ", "
+               << internal::colorNumber(color)
+               << instruction::signext64<12>(instruction::getITypeImm(bits))
+               << internal::colorReset(color) << "("
+               << internal::colorReg(color) << "x" << instruction::getRs1(bits)
+               << internal::colorReset(color) << ")";
+            return ss.str();
+        }
+    }
+    return internal::disassemble(bits, pc, color);
+}
+} // namespace inst
+} // namespace isa

--- a/src/hart/isa/inst-execute.h
+++ b/src/hart/isa/inst-execute.h
@@ -1,0 +1,19 @@
+#ifndef ZIRCON_HART_ISA_INST_EXECUTE_H_
+#define ZIRCON_HART_ISA_INST_EXECUTE_H_
+
+#include "inst.h"
+
+#include "hart/hart.h"
+
+#include <string>
+
+namespace isa {
+
+namespace inst {
+
+void executeInstruction(uint32_t bits, hart::HartState& hs);
+std::string disassemble(uint32_t bits, uint32_t pc = 0, bool color = false);
+
+}; // namespace inst
+}; // namespace isa
+#endif

--- a/src/hart/isa/inst.cpp
+++ b/src/hart/isa/inst.cpp
@@ -1,5 +1,7 @@
 #include "inst.h"
 
+#include "hart/hart.h"
+
 #include <sstream>
 
 #include "instruction_match.h"
@@ -11,6 +13,14 @@ namespace inst {
 namespace internal {
 extern const std::string& getOpcodeNameFromTable(Opcode op);
 extern const std::string& getOpcodeNiceNameFromTable(Opcode op);
+extern const std::string& getPrefixFromTable(Opcode op);
+extern const Opcode getOpcodeFromTable(std::string prefix, std::string name);
+extern const Opcode getOpcodeFromTable(std::string name);
+
+extern uint64_t getOpcodeFieldFromTable(Opcode op);
+extern uint64_t getFunct7FieldFromTable(Opcode op);
+extern uint64_t getFunct3FieldFromTable(Opcode op);
+
 extern Opcode decodeInstruction(uint32_t bits);
 extern void executeInstruction(uint32_t bits, hart::HartState& hs);
 extern std::string disassemble(uint32_t bits, uint32_t pc, bool color);
@@ -35,88 +45,41 @@ const std::string& Opcode::getNiceName(Opcode op) {
     }
     return internal::getOpcodeNiceNameFromTable(op);
 }
+const std::string& Opcode::getBareName(Opcode op) {
+    switch(op) {
+        default: break;
+    }
+    return internal::getOpcodeNiceNameFromTable(op);
+}
+const std::string& Opcode::getPrefix(Opcode op) {
+    switch(op) {
+        default: break;
+    }
+    return internal::getPrefixFromTable(op);
+}
+
+const Opcode Opcode::lookupName(std::string prefix, std::string name) {
+    return internal::getOpcodeFromTable(prefix, name);
+}
+const Opcode Opcode::lookupName(std::string name) {
+    return internal::getOpcodeFromTable(name);
+}
+
+uint64_t Opcode::getOpcodeField(Opcode op) {
+    return internal::getOpcodeFieldFromTable(op);
+}
+uint64_t Opcode::getFunct7Field(Opcode op) {
+    return internal::getFunct7FieldFromTable(op);
+}
+uint64_t Opcode::getFunct3Field(Opcode op) {
+    return internal::getFunct3FieldFromTable(op);
+}
 
 Opcode decodeInstruction(uint32_t bits) {
     Opcode op = internal::decodeInstruction(bits);
     if(op != Opcode::UNKNOWN) return op;
     // custom logic
     return op;
-}
-
-std::string fields(uint32_t bits) {
-    // print func separated as R, I, S, B, U, J
-    std::stringstream ss;
-
-    ss << "R-Type |f7     |rs2  |rs1  |f3 |rd   |opcode \n";
-    ss << "       |" << std::bitset<7>(instruction::getFunct7(bits)) << "|"
-       << std::bitset<5>(instruction::getRs2(bits)) << "|"
-       << std::bitset<5>(instruction::getRs1(bits)) << "|"
-       << std::bitset<3>(instruction::getFunct3(bits)) << "|"
-       << std::bitset<5>(instruction::getRd(bits)) << "|"
-       << std::bitset<7>(instruction::getOpcode(bits));
-    ss << "\n";
-    ss << "I-Type |i11:0        |rs1  |f3 |rd   |opcode \n";
-    ss << "       |"
-       << std::bitset<12>(instruction::getBitsFromLSB<20, 12>(bits)) << " |"
-       << std::bitset<5>(instruction::getRs1(bits)) << "|"
-       << std::bitset<3>(instruction::getFunct3(bits)) << "|"
-       << std::bitset<5>(instruction::getRd(bits)) << "|"
-       << std::bitset<7>(instruction::getOpcode(bits));
-    ss << "\n";
-    ss << "S-Type |i11:5  |rs2  |rs1  |f3 |i4:0 |opcode \n";
-    ss << "       |" << std::bitset<7>(instruction::getBitsFromLSB<25, 7>(bits))
-       << "|" << std::bitset<5>(instruction::getRs2(bits)) << "|"
-       << std::bitset<5>(instruction::getRs1(bits)) << "|"
-       << std::bitset<3>(instruction::getFunct3(bits)) << "|"
-       << std::bitset<5>(instruction::getBitsFromLSB<7, 5>(bits)) << "|"
-       << std::bitset<7>(instruction::getOpcode(bits));
-    ss << "\n";
-    return ss.str();
-}
-void executeInstruction(uint32_t bits, hart::HartState& hs) {
-    Opcode op = decodeInstruction(bits);
-    switch(op) {
-        default: break;
-    }
-    internal::executeInstruction(bits, hs);
-}
-
-std::string disassemble(uint32_t bits, uint32_t pc, bool color) {
-    Opcode op = decodeInstruction(bits);
-    switch(op) {
-        default: break;
-        case Opcode::rv32i_auipc: {
-            std::stringstream ss;
-            ss << internal::colorOpcode(color) << Opcode::getNiceName(op)
-               << internal::colorReset(color) << " "
-               << internal::colorReg(color) << "x" << instruction::getRd(bits)
-               << internal::colorReset(color) << ", "
-               << internal::colorNumber(color) << "0x" << std::hex
-               << (instruction::getUTypeImm(bits) >> 12)
-               << internal::colorReset(color);
-            return ss.str();
-        }
-        case Opcode::rv32i_lb:
-        case Opcode::rv32i_lh:
-        case Opcode::rv32i_lw:
-        case Opcode::rv32i_lbu:
-        case Opcode::rv32i_lhu:
-        case Opcode::rv64i_lwu:
-        case Opcode::rv64i_ld: {
-            std::stringstream ss;
-            ss << internal::colorOpcode(color) << Opcode::getNiceName(op)
-               << internal::colorReset(color) << " "
-               << internal::colorReg(color) << "x" << instruction::getRd(bits)
-               << internal::colorReset(color) << ", "
-               << internal::colorNumber(color)
-               << instruction::signext64<12>(instruction::getITypeImm(bits))
-               << internal::colorReset(color) << "("
-               << internal::colorReg(color) << "x" << instruction::getRs1(bits)
-               << internal::colorReset(color) << ")";
-            return ss.str();
-        }
-    }
-    return internal::disassemble(bits, pc, color);
 }
 
 }; // namespace inst

--- a/src/hart/isa/inst.h
+++ b/src/hart/isa/inst.h
@@ -1,8 +1,6 @@
 #ifndef ZIRCON_HART_ISA_INST_H_
 #define ZIRCON_HART_ISA_INST_H_
 
-#include "hart/hart.h"
-
 #include <string>
 
 namespace isa {
@@ -34,6 +32,17 @@ struct Opcode {
 
     static const std::string& getName(Opcode op);
     static const std::string& getNiceName(Opcode op);
+
+    static const std::string& getPrefix(Opcode op);
+    static const std::string& getBareName(Opcode op);
+
+    static const Opcode lookupName(std::string prefix, std::string name);
+    static const Opcode lookupName(std::string name);
+
+    static uint64_t getOpcodeField(Opcode op);
+    static uint64_t getFunct7Field(Opcode op);
+    static uint64_t getFunct3Field(Opcode op);
+
     static constexpr size_t size();
 
     bool isRType() const;
@@ -48,9 +57,6 @@ struct Opcode {
 };
 
 Opcode decodeInstruction(uint32_t bits);
-std::string fields(uint32_t bits);
-void executeInstruction(uint32_t bits, hart::HartState& hs);
-std::string disassemble(uint32_t bits, uint32_t pc = 0, bool color = false);
 
 }; // namespace inst
 }; // namespace isa

--- a/src/hart/isa/inst_internal.cpp
+++ b/src/hart/isa/inst_internal.cpp
@@ -1,6 +1,7 @@
 #include "inst.h"
 
 #include "color/color.h"
+#include "common/utils.h"
 #include "hart/syscall/syscall.h"
 
 #include <sstream>
@@ -125,12 +126,107 @@ std::string OPCODE_NICE_NAME_TABLE[] = {
 #define CUSTOM(prefix, name, ...) #name,
 #include "defs/instructions.inc"
 };
+std::string OPCODE_PREFIX_TABLE[] = {
+    "UNKNOWN",
+#define R_TYPE(prefix, ...) #prefix,
+#define I_TYPE(prefix, ...) #prefix,
+#define S_TYPE(prefix, ...) #prefix,
+#define B_TYPE(prefix, ...) #prefix,
+#define U_TYPE(prefix, ...) #prefix,
+#define J_TYPE(prefix, ...) #prefix,
+#define CUSTOM(prefix, ...) #prefix,
+#include "defs/instructions.inc"
+};
 
 const std::string& getOpcodeNameFromTable(Opcode op) {
     return OPCODE_NAME_TABLE[op];
 }
 const std::string& getOpcodeNiceNameFromTable(Opcode op) {
     return OPCODE_NICE_NAME_TABLE[op];
+}
+const std::string& getPrefixFromTable(Opcode op) {
+    return OPCODE_PREFIX_TABLE[op];
+}
+
+const Opcode getOpcodeFromTable(std::string argPrefix, std::string argName) {
+#define CHECK_NAME_PREC(prefix, name)                                          \
+    if(common::utils::tolower(#prefix) == common::utils::tolower(argPrefix) && \
+       common::utils::tolower(#name) == common::utils::tolower(argName)) {     \
+        return Opcode::prefix##_##name;                                        \
+    }
+#define R_TYPE(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#define I_TYPE(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#define S_TYPE(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#define B_TYPE(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#define U_TYPE(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#define J_TYPE(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#define CUSTOM(prefix, name, ...) CHECK_NAME_PREC(prefix, name)
+#include "defs/instructions.inc"
+#undef CHECK_NAME_PREC
+    return Opcode::UNKNOWN;
+}
+
+uint64_t getOpcodeFieldFromTable(Opcode op) {
+#define GET_OPCODE_FIELD(prefix, name, opcode)                                 \
+    if(Opcode::prefix##_##name == op) {                                        \
+        return opcode;                                                         \
+    }
+#define R_TYPE(prefix, name, opcode, funct7, funct3, execution, precedence)    \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#define I_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#define S_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#define B_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#define U_TYPE(prefix, name, opcode, execution, precedence)                    \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#define J_TYPE(prefix, name, opcode, execution, precedence)                    \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#define CUSTOM(prefix, name, opcode, matcher, printer, execution, precedence)  \
+    GET_OPCODE_FIELD(prefix, name, opcode)
+#include "defs/instructions.inc"
+#undef GET_OPCODE_FIELD
+    return 0;
+}
+uint64_t getFunct7FieldFromTable(Opcode op) {
+#define GET_FUNCT7_FIELD(prefix, name, funct7)                                 \
+    if(Opcode::prefix##_##name == op) {                                        \
+        return funct7;                                                         \
+    }
+#define R_TYPE(prefix, name, opcode, funct7, funct3, execution, precedence)    \
+    GET_FUNCT7_FIELD(prefix, name, funct7)
+#define I_TYPE(prefix, name, opcode, funct3, execution, precedence) return 0;
+#define S_TYPE(prefix, name, opcode, funct3, execution, precedence) return 0;
+#define B_TYPE(prefix, name, opcode, funct3, execution, precedence) return 0;
+#define U_TYPE(prefix, name, opcode, execution, precedence) return 0;
+#define J_TYPE(prefix, name, opcode, execution, precedence) return 0;
+#define CUSTOM(prefix, name, opcode, matcher, printer, execution, precedence)  \
+    return 0;
+#include "defs/instructions.inc"
+#undef GET_FUNCT7_FIELD
+    return 0;
+}
+uint64_t getFunct3FieldFromTable(Opcode op) {
+#define GET_FUNCT3_FIELD(prefix, name, funct3)                                 \
+    if(Opcode::prefix##_##name == op) {                                        \
+        return funct3;                                                         \
+    }
+#define R_TYPE(prefix, name, opcode, funct7, funct3, execution, precedence)    \
+    GET_FUNCT3_FIELD(prefix, name, funct3)
+#define I_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    GET_FUNCT3_FIELD(prefix, name, funct3)
+#define S_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    GET_FUNCT3_FIELD(prefix, name, funct3)
+#define B_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    GET_FUNCT3_FIELD(prefix, name, funct3)
+#define U_TYPE(prefix, name, opcode, execution, precedence) return 0;
+#define J_TYPE(prefix, name, opcode, execution, precedence) return 0;
+#define CUSTOM(prefix, name, opcode, matcher, printer, execution, precedence)  \
+    return 0;
+#include "defs/instructions.inc"
+#undef GET_FUNCT3_FIELD
+    return 0;
 }
 
 uint64_t OPCODE_PRECEDENCE[] = {
@@ -206,6 +302,35 @@ Opcode decodeInstruction(uint32_t bits) {
     if(prefix##_##name##_matcher_func(bits)) matched = Opcode::prefix##_##name;
 #include "defs/instructions.inc"
 
+    return matched;
+}
+
+// use precedence, rather than prefix, to distinguish
+// this is SLOW
+const Opcode getOpcodeFromTable(std::string arg) {
+    Opcode matched = Opcode::UNKNOWN;
+#define CHECK_NAME_PREC(prefix, name, precedence)                              \
+    if(common::utils::tolower(#name) == common::utils::tolower(arg) &&         \
+       (matched == Opcode::UNKNOWN ||                                          \
+        precedence < getOpcodePrecedence(matched))) {                          \
+        matched = Opcode::prefix##_##name;                                     \
+    }
+#define R_TYPE(prefix, name, opcode, funct7, funct3, execution, precedence)    \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#define I_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#define S_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#define B_TYPE(prefix, name, opcode, funct3, execution, precedence)            \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#define U_TYPE(prefix, name, opcode, execution, precedence)                    \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#define J_TYPE(prefix, name, opcode, execution, precedence)                    \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#define CUSTOM(prefix, name, opcode, matcher, printer, execution, precedence)  \
+    CHECK_NAME_PREC(prefix, name, precedence)
+#include "defs/instructions.inc"
+#undef CHECK_NAME_PREC
     return matched;
 }
 

--- a/src/hart/isa/instruction_match.h
+++ b/src/hart/isa/instruction_match.h
@@ -9,28 +9,74 @@ using Word = uint32_t;
 // get a mask with N bits
 template <std::size_t N> constexpr Word getMask() {
     static_assert(N <= sizeof(Word) * 8, "Invalid Bit Length");
-    return (1ULL << N) - 1;
+    return 0xFFFFFFFFULL >> ((sizeof(Word) * 8) - N);
 }
-template <std::size_t N, std::size_t COUNT>
+
+template <std::size_t LSB, std::size_t COUNT>
 constexpr Word getBitsFromLSB(Word bits) {
-    static_assert(N < sizeof(Word) * 8, "Invalid Index");
-    return (bits >> N) & getMask<COUNT>();
+    static_assert(LSB < sizeof(Word) * 8, "Invalid Index");
+    return (bits >> LSB) & getMask<COUNT>();
 }
+template <std::size_t LSB, std::size_t COUNT>
+constexpr Word clearBitsFromLSB(Word bits) {
+    static_assert(LSB < sizeof(Word) * 8, "Invalid Index");
+    return bits & ~(getMask<COUNT>() << LSB);
+}
+template <std::size_t LSB, std::size_t COUNT>
+constexpr Word setBitsFromLSB(Word bits, Word toSet) {
+    static_assert(LSB < sizeof(Word) * 8, "Invalid Index");
+    Word toSetMask = toSet & getMask<COUNT>();
+    Word bitsClear = clearBitsFromLSB<LSB, COUNT>(bits);
+    Word bitsSet = bitsClear | (toSetMask << LSB);
+    return bitsSet;
+}
+
 template <std::size_t N> constexpr Word getBit(Word bits) {
     static_assert(N < sizeof(Word) * 8, "Invalid Index");
-    // return (bits >> N) & 1;
     return getBitsFromLSB<N, 1>(bits);
 }
-template <std::size_t N, std::size_t COUNT>
-constexpr Word getBitsFromMSB(Word bits) {
+template <std::size_t N> constexpr Word clearBit(Word bits) {
     static_assert(N < sizeof(Word) * 8, "Invalid Index");
-    return getBitsFromLSB<N - COUNT + 1, COUNT>(bits);
+    return clearBitsFromLSB<N, 1>(bits);
 }
-// inclusive
-template <std::size_t N, std::size_t M> constexpr Word getBitRange(Word bits) {
-    static_assert(N < sizeof(Word) * 8 && N >= M, "Invalid Indexes");
-    return (bits >> M) & getMask<N - M + 1>();
+template <std::size_t N> constexpr Word setBit(Word bits, Word toSet) {
+    static_assert(N < sizeof(Word) * 8, "Invalid Index");
+    return setBitsFromLSB<N, 1>(bits, toSet);
 }
+
+template <std::size_t MSB, std::size_t COUNT>
+constexpr Word getBitsFromMSB(Word bits) {
+    static_assert(MSB < sizeof(Word) * 8, "Invalid Index");
+    return getBitsFromLSB<MSB - COUNT + 1, COUNT>(bits);
+}
+template <std::size_t MSB, std::size_t COUNT>
+constexpr Word clearBitsFromMSB(Word bits) {
+    static_assert(MSB < sizeof(Word) * 8, "Invalid Index");
+    return clearBitsFromLSB<MSB - COUNT + 1, COUNT>(bits);
+}
+template <std::size_t MSB, std::size_t COUNT>
+constexpr Word setBitsFromMSB(Word bits, Word toSet) {
+    static_assert(MSB < sizeof(Word) * 8, "Invalid Index");
+    return setBitsFromLSB<MSB - COUNT + 1, COUNT>(bits, toSet);
+}
+
+// inclusive, MSB to LSB
+template <std::size_t MSB, std::size_t LSB>
+constexpr Word getBitRange(Word bits) {
+    static_assert(MSB < sizeof(Word) * 8 && MSB >= LSB, "Invalid Indexes");
+    return getBitsFromLSB<LSB, MSB - LSB + 1>(bits);
+}
+template <std::size_t MSB, std::size_t LSB>
+constexpr Word clearBitRange(Word bits) {
+    static_assert(MSB < sizeof(Word) * 8 && MSB >= LSB, "Invalid Indexes");
+    return clearBitsFromLSB<LSB, MSB - LSB + 1>(bits);
+}
+template <std::size_t MSB, std::size_t LSB>
+constexpr Word setBitRange(Word bits, Word toSet) {
+    static_assert(MSB < sizeof(Word) * 8 && MSB >= LSB, "Invalid Indexes");
+    return setBitsFromLSB<LSB, MSB - LSB + 1>(bits, toSet);
+}
+
 template <std::size_t B> constexpr __int128_t signext128(uint64_t value) {
     static_assert(B <= 128 && B >= 0, "Invalid Size");
     return __int128_t(value);
@@ -46,37 +92,128 @@ template <std::size_t B> constexpr int32_t signext32(uint32_t value) {
 }
 
 constexpr Word getOpcode(Word bits) { return getBitsFromLSB<0, 7>(bits); }
+constexpr Word setOpcode(Word bits, Word toSet) {
+    return setBitsFromLSB<0, 7>(bits, toSet);
+}
+
 constexpr Word getFunct7(Word bits) { return getBitsFromLSB<25, 7>(bits); }
+constexpr Word setFunct7(Word bits, Word toSet) {
+    return setBitsFromLSB<25, 7>(bits, toSet);
+}
+
 constexpr Word getFunct3(Word bits) { return getBitsFromLSB<12, 3>(bits); }
+constexpr Word setFunct3(Word bits, Word toSet) {
+    return setBitsFromLSB<12, 3>(bits, toSet);
+}
+
 constexpr Word getRd(Word bits) { return getBitsFromLSB<7, 5>(bits); }
+constexpr Word setRd(Word bits, Word toSet) {
+    return setBitsFromLSB<7, 5>(bits, toSet);
+}
+
 constexpr Word getRs2(Word bits) { return getBitsFromLSB<20, 5>(bits); }
+constexpr Word setRs2(Word bits, Word toSet) {
+    return setBitsFromLSB<20, 5>(bits, toSet);
+}
+
 constexpr Word getRs1(Word bits) { return getBitsFromLSB<15, 5>(bits); }
+constexpr Word setRs1(Word bits, Word toSet) {
+    return setBitsFromLSB<15, 5>(bits, toSet);
+}
+
 constexpr Word getShamt5(Word bits) { return getBitsFromLSB<20, 5>(bits); }
+constexpr Word setShamt5(Word bits, Word toSet) {
+    return setBitsFromLSB<20, 5>(bits, toSet);
+}
+
 constexpr Word getShamt6(Word bits) { return getBitsFromLSB<20, 6>(bits); }
+constexpr Word setShamt6(Word bits, Word toSet) {
+    return setBitsFromLSB<20, 6>(bits, toSet);
+}
 
 constexpr Word getITypeImm(Word bits) { return getBitsFromLSB<20, 12>(bits); }
-constexpr Word getSTypeImm(Word bits) {
-    return (/*imm11_5*/ getBitsFromLSB<25, 7>(bits) << 5) |
-           (/*imm4_0*/ getBitsFromLSB<7, 5>(bits));
+constexpr Word setITypeImm(Word bits, Word toSet) {
+    return setBitsFromLSB<20, 12>(bits, toSet);
 }
+
+constexpr Word getSTypeImm(Word bits) {
+    Word bits25_7 = getBitsFromLSB<25, 7>(bits);
+    Word bits7_5 = getBitsFromLSB<7, 5>(bits);
+
+    Word imm11_5 = setBitRange<11, 5>(0, bits25_7);
+    Word imm4_0 = setBitRange<4, 0>(0, bits7_5);
+    return imm11_5 | imm4_0;
+}
+constexpr Word setSTypeImm(Word bits, Word toSet) {
+    Word imm11_5 = getBitRange<11, 5>(toSet);
+    Word imm4_0 = getBitRange<4, 0>(toSet);
+
+    bits = setBitsFromLSB<25, 7>(bits, imm11_5);
+    bits = setBitsFromLSB<7, 5>(bits, imm4_0);
+    return bits;
+}
+
 constexpr Word getBTypeImm(Word bits) {
-    // return (/*imm12*/ getBitsFromLSB<31, 1>(bits) << 12) |
-    //        (/*imm10_5*/ getBitsFromLSB<25, 6>(bits) << 5) |
-    //        (/*imm4_1*/ getBitsFromLSB<8, 4>(bits) << 1) |
-    //        (/*imm11*/ getBitsFromLSB<7, 1>(bits) << 11);
-    return (/*imm12*/ getBitRange<31, 31>(bits) << 12) |
-           (/*imm10_5*/ getBitRange<30, 25>(bits) << 5) |
-           (/*imm4_1*/ getBitRange<11, 8>(bits) << 1) |
-           (/*imm11*/ getBitRange<7, 7>(bits) << 11);
+    Word bits31 = getBit<31>(bits);
+    Word bits30_25 = getBitRange<30, 25>(bits);
+    Word bits11_8 = getBitRange<11, 8>(bits);
+    Word bits7 = getBit<7>(bits);
+
+    Word imm12 = setBit<12>(0, bits31);
+    Word imm10_5 = setBitRange<10, 5>(0, bits30_25);
+    Word imm4_1 = setBitRange<4, 1>(0, bits11_8);
+    Word imm11 = setBit<11>(0, bits7);
+
+    return imm12 | imm10_5 | imm4_1 | imm11;
+}
+constexpr Word setBTypeImm(Word bits, Word toSet) {
+    Word imm12 = getBit<12>(toSet);
+    Word imm10_5 = getBitRange<10, 5>(toSet);
+    Word imm4_1 = getBitRange<4, 1>(toSet);
+    Word imm11 = getBit<11>(toSet);
+
+    bits = setBit<31>(bits, imm12);
+    bits = setBitRange<30, 25>(bits, imm10_5);
+    bits = setBitRange<11, 8>(bits, imm4_1);
+    bits = setBit<7>(bits, imm11);
+    return bits;
 }
 constexpr Word getUTypeImm(Word bits) {
-    return (/*imm31_12*/ getBitsFromLSB<12, 20>(bits) << 12);
+    Word bits12_20 = getBitsFromLSB<12, 20>(bits);
+    Word imm31_12 = setBitRange<31, 12>(0, bits12_20);
+    return imm31_12;
+}
+constexpr Word setUTypeImm(Word bits, Word toSet) {
+    Word imm31_12 = getBitRange<31, 12>(toSet);
+    bits = setBitsFromLSB<12, 20>(bits, imm31_12);
+    return bits;
 }
 constexpr Word getJTypeImm(Word bits) {
-    return (/*imm20*/ getBitsFromLSB<31, 1>(bits) << 20) |
-           (/*imm10_1*/ getBitsFromLSB<21, 10>(bits) << 1) |
-           (/*imm11*/ getBitsFromLSB<20, 1>(bits) << 11) |
-           (/*imm19_12*/ getBitsFromLSB<12, 8>(bits) << 12);
+    Word bits31 = getBit<31>(bits);
+    Word bits21_10 = getBitsFromLSB<21, 10>(bits);
+    Word bits20 = getBit<20>(bits);
+    Word bits12_8 = getBitsFromLSB<12, 8>(bits);
+
+    Word imm20 = setBit<20>(0, bits31);
+    Word imm10_1 = setBitRange<10, 1>(0, bits21_10);
+    Word imm11 = setBit<11>(0, bits20);
+    Word imm19_12 = setBitRange<19, 12>(0, bits12_8);
+
+    return imm20 | imm10_1 | imm11 | imm19_12;
+}
+constexpr Word setJTypeImm(Word bits, Word toSet) {
+
+    Word imm20 = getBit<20>(toSet);
+    Word imm10_1 = getBitRange<10, 1>(toSet);
+    Word imm11 = getBit<11>(toSet);
+    Word imm19_12 = getBitRange<19, 12>(toSet);
+
+    bits = setBit<31>(bits, imm20);
+    bits = setBitsFromLSB<21, 10>(bits, imm10_1);
+    bits = setBit<20>(bits, imm11);
+    bits = setBitsFromLSB<12, 8>(bits, imm19_12);
+
+    return bits;
 }
 }; // namespace instruction
 

--- a/src/hart/isa/rf.h
+++ b/src/hart/isa/rf.h
@@ -63,7 +63,8 @@ class RegisterFile {
     RegisterClass classname = {                                                \
         #classname,                                                            \
         #reg_prefix,                                                           \
-        number_regs, REGISTER_CLASS_##classname(REG_CASE)};                               \
+        number_regs,                                                           \
+        REGISTER_CLASS_##classname(REG_CASE)};                                 \
     template <typename T> void add##classname##ReadListener(T&& arg) {         \
         classname.addReadListener(std::forward<T>(arg));                       \
     }                                                                          \

--- a/src/hart/syscall/syscall.inc
+++ b/src/hart/syscall/syscall.inc
@@ -23,7 +23,6 @@
 /*this allows an application to override existing ones*/
 #include "generated-definition/syscalls.inc"
 
-
 // MAP_SYSCALL(read, 0, 63, fd, buf, count)
 // MAP_SYSCALL(write, 1, 64, fd, buf, count)
 // MAP_SYSCALL(close, 3, 57, fd)

--- a/src/inst-builder/Makefile
+++ b/src/inst-builder/Makefile
@@ -1,0 +1,5 @@
+-include $(ROOT_PROJECT_DIRECTORY)options.mk
+-include $(ROOT_PROJECT_DIRECTORY)src/dependencies.mk
+LIBRARIES= $(inst-builder)
+TARGET=$(BIN_DIRECTORY)inst-builder
+-include $(ROOT_PROJECT_DIRECTORY)src/executable.mk

--- a/src/inst-builder/main.cpp
+++ b/src/inst-builder/main.cpp
@@ -1,0 +1,251 @@
+
+
+#include "common/argparse.hpp"
+#include "common/format.h"
+#include "hart/isa/inst.h"
+#include "hart/isa/instruction_match.h"
+
+#include <cstdint>
+#include <iostream>
+#include <ostream>
+#include <string>
+
+/*
+everything read as hex
+./ib  -f I -o op -3 0x1 -7 -1 -rd 0 -rs1 -rs2 -i imm
+./ib  -prefix -name
+./ib  -prefix -name -rd -rs1 -rs2
+*/
+
+// TODO: does not really support custom inst
+// TODO; does not support SHAMT
+
+enum class InstructionFormat { NONE, R, I, S, B, U, J };
+InstructionFormat parseInstructionFormat(const std::string& s) {
+    if(s == "R" || s == "r") return InstructionFormat::R;
+    if(s == "I" || s == "i") return InstructionFormat::I;
+    if(s == "S" || s == "s") return InstructionFormat::S;
+    if(s == "B" || s == "b") return InstructionFormat::B;
+    if(s == "U" || s == "u") return InstructionFormat::U;
+    if(s == "J" || s == "j") return InstructionFormat::J;
+    return InstructionFormat::NONE;
+}
+std::ostream& operator<<(std::ostream& os, InstructionFormat i) {
+    if(i == InstructionFormat::R) os << "R";
+    else if(i == InstructionFormat::I) os << "I";
+    else if(i == InstructionFormat::S) os << "S";
+    else if(i == InstructionFormat::B) os << "B";
+    else if(i == InstructionFormat::U) os << "U";
+    else if(i == InstructionFormat::J) os << "J";
+    else os << "NONE";
+    return os;
+}
+InstructionFormat getFormatFromOpcode(isa::inst::Opcode op) {
+    if(op.isRType()) return InstructionFormat::R;
+    if(op.isIType()) return InstructionFormat::I;
+    if(op.isSType()) return InstructionFormat::S;
+    if(op.isBType()) return InstructionFormat::B;
+    if(op.isUType()) return InstructionFormat::U;
+    if(op.isJType()) return InstructionFormat::J;
+    return InstructionFormat::NONE;
+}
+
+struct Instruction {
+    std::string prefix;
+    std::string name;
+    InstructionFormat format;
+    uint32_t opcode;
+    uint32_t funct7;
+    uint32_t funct3;
+    uint32_t rd;
+    uint32_t rs2;
+    uint32_t rs1;
+    uint32_t raw_imm;
+
+    Instruction()
+        : prefix(std::string("")), name(std::string("")),
+          format(InstructionFormat::NONE), opcode(), funct7(), funct3(), rd(),
+          rs2(), rs1(), raw_imm(){};
+
+  private:
+    void setInfoFromOpcode(isa::inst::Opcode op) {
+        this->prefix = isa::inst::Opcode::getPrefix(op);
+        this->name = isa::inst::Opcode::getBareName(op);
+        this->format = getFormatFromOpcode(op);
+        this->opcode = isa::inst::Opcode::getOpcodeField(op);
+        this->funct7 = isa::inst::Opcode::getFunct7Field(op);
+        this->funct3 = isa::inst::Opcode::getFunct3Field(op);
+    }
+
+  public:
+    void setKnownInstruction(std::string prefix, std::string name) {
+        auto op = isa::inst::Opcode::lookupName(prefix, name);
+        setInfoFromOpcode(op);
+    }
+    void setKnownInstruction(std::string name) {
+        auto op = isa::inst::Opcode::lookupName(name);
+        setInfoFromOpcode(op);
+    }
+
+    uint32_t build() {
+        switch(format) {
+            case InstructionFormat::R: {
+                uint32_t bits = 0;
+                bits = instruction::setOpcode(bits, opcode);
+                bits = instruction::setFunct7(bits, funct7);
+                bits = instruction::setFunct3(bits, funct3);
+                bits = instruction::setRd(bits, rd);
+                bits = instruction::setRs2(bits, rs2);
+                bits = instruction::setRs1(bits, rs1);
+                return bits;
+            }
+            case InstructionFormat::I: {
+                uint32_t bits = 0;
+                bits = instruction::setOpcode(bits, opcode);
+                bits = instruction::setFunct3(bits, funct3);
+                bits = instruction::setRd(bits, rd);
+                bits = instruction::setRs1(bits, rs1);
+                bits = instruction::setITypeImm(bits, raw_imm);
+                return bits;
+            }
+            case InstructionFormat::S: {
+                uint32_t bits = 0;
+                bits = instruction::setOpcode(bits, opcode);
+                bits = instruction::setFunct3(bits, funct3);
+                bits = instruction::setRs2(bits, rs2);
+                bits = instruction::setRs1(bits, rs1);
+                bits = instruction::setSTypeImm(bits, raw_imm);
+                return bits;
+            }
+            case InstructionFormat::B: {
+                uint32_t bits = 0;
+                bits = instruction::setOpcode(bits, opcode);
+                bits = instruction::setFunct3(bits, funct3);
+                bits = instruction::setRs2(bits, rs2);
+                bits = instruction::setRs1(bits, rs1);
+                bits = instruction::setBTypeImm(bits, raw_imm);
+                return bits;
+            }
+            case InstructionFormat::U: {
+                uint32_t bits = 0;
+                bits = instruction::setOpcode(bits, opcode);
+                bits = instruction::setRd(bits, rd);
+                bits = instruction::setUTypeImm(bits, raw_imm);
+                return bits;
+            }
+            case InstructionFormat::J: {
+                uint32_t bits = 0;
+                bits = instruction::setOpcode(bits, opcode);
+                bits = instruction::setRd(bits, rd);
+                bits = instruction::setJTypeImm(bits, raw_imm);
+                return bits;
+            }
+            default: {
+                uint32_t bits = 0;
+                // do our best, do nothing with the IMM
+                if(opcode) bits = instruction::setOpcode(bits, opcode);
+                if(funct7) bits = instruction::setFunct7(bits, funct7);
+                if(funct3) bits = instruction::setFunct3(bits, funct3);
+                if(rd) bits = instruction::setRd(bits, rd);
+                if(rs2) bits = instruction::setRs2(bits, rs2);
+                if(rs1) bits = instruction::setRs1(bits, rs1);
+                return bits;
+            }
+        }
+    }
+
+    std::string info() {
+        auto bits = build();
+        auto op = isa::inst::decodeInstruction(bits);
+        if(op != isa::inst::Opcode::UNKNOWN)
+            return isa::inst::Opcode::getPrefix(op) + "." +
+                   isa::inst::Opcode::getBareName(op);
+        else return "UNKNOWN";
+    }
+};
+
+auto get_args() {
+    argparse::ArgumentParser args;
+
+    args.add_argument("-f")
+        .default_value(InstructionFormat::NONE)
+        .action([](const std::string& value) {
+            return parseInstructionFormat(value);
+        })
+        .help("which format to use");
+    args.add_argument("-op")
+        .default_value(std::string("0"))
+        .help("opcode field, 7 bits");
+
+    args.add_argument("-f7")
+        .default_value(std::string("0"))
+        .help("funct7 field, 7 bits");
+    args.add_argument("-f3")
+        .default_value(std::string("0"))
+        .help("funct3 field, 3 bits");
+
+    args.add_argument("-rd")
+        .default_value(std::string("0"))
+        .help("rd field, 5 bits");
+
+    args.add_argument("-rs2")
+        .default_value(std::string("0"))
+        .help("rs2 field, 5 bits");
+    args.add_argument("-rs1")
+        .default_value(std::string("0"))
+        .help("rs1 field, 5 bits");
+
+    args.add_argument("-i")
+        .default_value(std::string("0"))
+        .help("immediate field");
+
+    return args;
+}
+
+uint32_t parse_num(const std::string& s) {
+    if(s.size() >= 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
+        return std::stoull(s.substr(2), nullptr, 16);
+    else if(s.size() >= 2 && s[0] == '0' && (s[1] == 'b' || s[1] == 'B'))
+        return std::stoull(s.substr(2), nullptr, 2);
+    else return std::stoull(s, nullptr, 10);
+}
+
+Instruction get_instruction_from_args(argparse::ArgumentParser args) {
+    Instruction inst;
+    inst.format = args.get<InstructionFormat>("-f");
+    inst.opcode = parse_num(args.get<std::string>("-op"));
+    inst.funct3 = parse_num(args.get<std::string>("-f3"));
+    inst.funct7 = parse_num(args.get<std::string>("-f7"));
+    inst.rd = parse_num(args.get<std::string>("-rd"));
+    inst.rs1 = parse_num(args.get<std::string>("-rs1"));
+    inst.rs2 = parse_num(args.get<std::string>("-rs2"));
+    inst.raw_imm = parse_num(args.get<std::string>("-i"));
+    return inst;
+}
+
+int main(int argc, const char** argv) {
+
+    auto args = get_args();
+    try {
+        args.parse_args(argc, argv);
+    } catch(const std::runtime_error& err) {
+        std::cerr << err.what() << std::endl;
+        return 1;
+    }
+
+    auto inst = get_instruction_from_args(args);
+    std::cout << inst.info() << ": " << common::Format::word << inst.build()
+              << std::endl;
+
+    // uint32_t x = 0xFFFF;
+    // uint32_t clear = instruction::clearBitsFromLSB<8, 4>(x);
+    // std::cout << "0x" << common::Format::word << x << " 0x" <<
+    // common::Format::word << clear << std::endl;
+
+    // x = 0x0000;
+    // clear = instruction::setBitsFromLSB<8, 8>(x, 0xed);
+    // std::cout << "0x" << common::Format::word << x << " 0x" <<
+    // common::Format::word << clear << std::endl;
+
+    return 0;
+}

--- a/src/ishell/Makefile
+++ b/src/ishell/Makefile
@@ -7,4 +7,4 @@ TARGET_DEPENDS=$(GEN_DIRECTORY)parser/expr_parser_table.inc
 
 $(TARGET_DEPENDS):
 	@mkdir -p $(dir $(TARGET_DEPENDS))
-	$(AT)python3 $(SRC_PATH)parser/build-table.py $(SRC_PATH)parser/ExprParsing.ods >$@
+	$(PYTHON3) $(SRC_PATH)parser/build-table.py $(SRC_PATH)parser/ExprParsing.ods >$@

--- a/src/trace/stats.cpp
+++ b/src/trace/stats.cpp
@@ -1,5 +1,6 @@
 #include "stats.h"
 
+#include "hart/isa/inst-execute.h"
 #include "hart/isa/inst.h"
 
 #include <functional>

--- a/src/zircon-wasm/main.cpp
+++ b/src/zircon-wasm/main.cpp
@@ -3,6 +3,7 @@
 #include "common/format.h"
 #include "elf/elf.h"
 #include "hart/hart.h"
+#include "hart/isa/inst-execute.h"
 #include "hart/isa/inst.h"
 #include "mem/memory-image.h"
 

--- a/src/zircon/arguments.cpp
+++ b/src/zircon/arguments.cpp
@@ -4,6 +4,7 @@
 #include "common/debug.h"
 #include "common/format.h"
 #include "event/event.h"
+#include "hart/isa/inst-execute.h"
 #include "hart/isa/inst.h"
 #include "ishell/parser/parser.h"
 

--- a/tests/driver/TestDefinition.py
+++ b/tests/driver/TestDefinition.py
@@ -201,7 +201,11 @@ def _build_one_zircon(build_dir: str, name: str, cmd: str):
     if cmd is None:
         print("Unknown configuration for '" + name + "'")
         return False
-    cmd = "nice make " + cmd + f" BUILD='{os.path.join(build_dir, name)}' -j{mp.cpu_count()}"
+    cmd = (
+        "nice make "
+        + cmd
+        + f" BUILD='{os.path.join(build_dir, name)}' -j{mp.cpu_count()}"
+    )
     cmd = shlex.split(cmd)
     print(cmd)
     ret = sp.call(cmd, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
@@ -459,9 +463,11 @@ class TestConfiguration:
                 exp_sub_name = sub_name
             else:
                 sub_name = str(idx)
-                idx+=1
+                idx += 1
 
-            exp_file = exp_files["DEFAULT"] if not exp_sub_name else exp_files[exp_sub_name]
+            exp_file = (
+                exp_files["DEFAULT"] if not exp_sub_name else exp_files[exp_sub_name]
+            )
 
             (comp_config, exec_config, sim_config, toolchain_config) = configs
 


### PR DESCRIPTION
Add basic instruction builder tool, allows RISC-V instructions to be created easier

The following command builds `andi x5, x16, 0x777`

`./build/bin/inst-builder -f I -op 0x13 -f3 7 -rd 5 -rs1 16 -i 0x777`