### PR TITLE
fix linker issues with ld (and probably gold)

### DIFF
--- a/src/dependencies.mk
+++ b/src/dependencies.mk
@@ -9,8 +9,8 @@ command= hart
 common= hart
 trace= hart
 color= hart
-zircon= hart command ishell elf mem trace event color common
-zircon-wasm= hart command ishell elf mem trace event color common
+zircon= ishell hart command elf mem trace event color common
+zircon-wasm= ishell hart command elf mem trace event color common
 inst-builder= hart common
 
 define make_depen

--- a/tests/driver/config/COMPSIM
+++ b/tests/driver/config/COMPSIM
@@ -3,13 +3,13 @@ default= LINKER=lld
 debug= DEBUG=1 LINKER=lld
 
 
-# clang_with_ld= -B CC=clang CXX=clang++ CLINKER=ld
-# clang_with_gold= -B CC=clang CXX=clang++ LINKER=gold 
+clang_with_ld= -B CC=clang CXX=clang++ LINKER=ld
+clang_with_gold= -B CC=clang CXX=clang++ LINKER=gold 
 clang_with_lld= CC=clang CXX=clang++ LINKER=lld
 clang_with_mold= CC=clang CXX=clang++ LINKER=mold
 
 
-# gcc_with_ld= -B CC=gcc CXX=g++ CLINKER=ld
-# gcc_with_gold= -B CC=gcc CXX=g++ LINKER=gold 
+gcc_with_ld= -B CC=gcc CXX=g++ LINKER=ld
+gcc_with_gold= -B CC=gcc CXX=g++ LINKER=gold 
 gcc_with_lld= CC=gcc CXX=g++ LINKER=lld
 gcc_with_mold= CC=gcc CXX=g++ LINKER=mold


### PR DESCRIPTION
for some reason, although the vtable is defined in libcommand.a, libishell.a must be  linked first to get vtables to work this is not an issue with ld or mold
Other possible solutions where
- grepping all object files (*.o) and linking them directly rather than archives
- linking with `-Wl,--unresolved-symbols=ignore-all`