### PR TITLE
Bug fixes in ishell

### DIFF
--- a/src/command/action.h
+++ b/src/command/action.h
@@ -170,7 +170,7 @@ class Dump : public ActionBase {
         : Dump(nullptr, args_begin, args_end) {}
     template <class InputIt>
     Dump(hart::HartState* hs, InputIt args_begin, InputIt args_end)
-        : ActionBase(ActionType::WATCH, hs), args(args_begin, args_end) {}
+        : ActionBase(ActionType::DUMP, hs), args(args_begin, args_end) {}
     virtual ~Dump() = default;
     void action(std::ostream* o = nullptr) override;
     static bool classof(const ActionBase* ai) {

--- a/src/command/command.cpp
+++ b/src/command/command.cpp
@@ -82,8 +82,8 @@ CallbackCommand::CallbackCommand(
     }
 }
 
-void CallbackCommand::install(hart::Hart* hart) {
-    if(!hs || !hart) return;
+void CallbackCommand::install() {
+    if(!hs) return;
 // attach to all relevant events
 // use super classes doit
 #define CALLBACK_TO_INSTALL this->Command::doit(&std::cout);
@@ -91,35 +91,35 @@ void CallbackCommand::install(hart::Hart* hart) {
     for(auto event_type : this->events) {
         switch(event_type) {
             case event::EventType::HART_BEFORE_EXECUTE:
-                hart->addBeforeExecuteListener(
+                hs->getExecutingHart()->addBeforeExecuteListener(
                     [this](hart::HartState&) { CALLBACK_TO_INSTALL });
                 break;
             case event::EventType::HART_AFTER_EXECUTE:
-                hart->addAfterExecuteListener(
+                hs->getExecutingHart()->addAfterExecuteListener(
                     [this](hart::HartState&) { CALLBACK_TO_INSTALL });
                 break;
             case event::EventType::MEM_READ:
-                hart->hs().mem().addReadListener(
+                hs->getExecutingHart()->hs().mem().addReadListener(
                     [this](uint64_t, uint64_t, size_t) { CALLBACK_TO_INSTALL });
                 break;
             case event::EventType::MEM_WRITE:
-                hart->hs().mem().addWriteListener(
+                hs->getExecutingHart()->hs().mem().addWriteListener(
                     [this](uint64_t, uint64_t, uint64_t, size_t) {
                         CALLBACK_TO_INSTALL
                     });
                 break;
             case event::EventType::MEM_ALLOCATION:
-                hart->hs().mem().addAllocationListener(
+                hs->getExecutingHart()->hs().mem().addAllocationListener(
                     [this](uint64_t, uint64_t) { CALLBACK_TO_INSTALL });
                 break;
             case event::EventType::REG_READ:
-                hart->hs().rf().addReadListener(
+                hs->getExecutingHart()->hs().rf().addReadListener(
                     [this](std::string, uint64_t, uint64_t) {
                         CALLBACK_TO_INSTALL
                     });
                 break;
             case event::EventType::REG_WRITE:
-                hart->hs().rf().addWriteListener(
+                hs->getExecutingHart()->hs().rf().addWriteListener(
                     [this](std::string, uint64_t, uint64_t, uint64_t) {
                         CALLBACK_TO_INSTALL
                     });

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -61,7 +61,7 @@ class Command {
     virtual void setHS(hart::HartState* hs);
     virtual bool shouldDoit();
     virtual void doit([[maybe_unused]] std::ostream* o = nullptr);
-    virtual void install([[maybe_unused]] hart::Hart* hart) {
+    virtual void install() {
         // does nothing in the base case
     }
 };
@@ -119,7 +119,7 @@ class CallbackCommand : public Command {
 
     // override this classes doit, cannot call directly and should do nothing
     virtual void doit([[maybe_unused]] std::ostream* o = nullptr) override {}
-    virtual void install([[maybe_unused]] hart::Hart* hart) override;
+    virtual void install() override;
 };
 
 } // namespace command

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,5 +1,6 @@
 #ifndef ZIRCON_COMMON_UTILS_H_
 #define ZIRCON_COMMON_UTILS_H_
+#include <functional>
 #include <initializer_list>
 #include <string>
 #include <vector>
@@ -10,12 +11,28 @@ extern std::string toupper(const std::string& str);
 extern std::string tolower(const std::string& str);
 extern std::vector<std::string>
 split(const std::string& str, const std::string& sep = " ");
-template <class FWIt>
-std::string join(FWIt elms_begin, FWIt elms_end, const std::string& join = "") {
+template <class ForwardIT>
+std::string
+join(ForwardIT elms_begin, ForwardIT elms_end, const std::string& join = "") {
     std::string sep;
     std::string res;
     for(auto it = elms_begin; it != elms_end; it++) {
         res = res + sep + *it;
+        sep = join;
+    }
+    return res;
+}
+template <class ForwardIT>
+std::string join(
+    ForwardIT elms_begin,
+    ForwardIT elms_end,
+    std::function<
+        std::string(typename std::iterator_traits<ForwardIT>::value_type)> func,
+    const std::string& join = "") {
+    std::string sep;
+    std::string res;
+    for(auto it = elms_begin; it != elms_end; it++) {
+        res = res + sep + func(*it);
         sep = join;
     }
     return res;

--- a/src/hart/hart.cpp
+++ b/src/hart/hart.cpp
@@ -16,7 +16,7 @@
 namespace hart {
 
 Hart::Hart(std::shared_ptr<mem::MemoryImage> m)
-    : hs_(std::make_unique<HartState>(m)) {}
+    : hs_(std::make_unique<HartState>(this, m)) {}
 
 bool Hart::shouldHalt() {
     // if pc is beyond the bounds of memory , return true

--- a/src/hart/hartstate.cpp
+++ b/src/hart/hartstate.cpp
@@ -7,8 +7,8 @@ types::InstructionWord HartState::getInstWord() const {
     return *((types::InstructionWord*)ptr);
 }
 
-HartState::HartState(std::shared_ptr<mem::MemoryImage> m)
-    : rf_(std::make_unique<isa::rf::RegisterFile>()), memories_(),
+HartState::HartState(Hart* hart, std::shared_ptr<mem::MemoryImage> m)
+    : hart(hart), rf_(std::make_unique<isa::rf::RegisterFile>()), memories_(),
       execution_state(ExecutionState::STOPPED) {
     // insert memory image for address space 0
     this->memories_.insert_or_assign(0, m);

--- a/src/hart/hartstate.h
+++ b/src/hart/hartstate.h
@@ -31,6 +31,8 @@ class HartState {
     friend command::Expr;
 
   private:
+    // the hart current being executed
+    Hart* hart;
     std::unique_ptr<isa::rf::RegisterFile> rf_;
 
     struct MemoryPair {
@@ -136,10 +138,12 @@ class HartState {
     // use raw(addr) so we don't log mem access
     types::InstructionWord getInstWord() const;
 
-    HartState(std::shared_ptr<mem::MemoryImage> m);
+    HartState(Hart* hart, std::shared_ptr<mem::MemoryImage> m);
 
     HartState& operator()() { return *this; }
     const HartState& operator()() const { return *this; }
+
+    Hart* getExecutingHart() { return hart; }
 
     void setPC(types::Address start_address) { pc = start_address; }
     void start() { setExecutionState(ExecutionState::RUNNING); }

--- a/src/ishell/parser/expr_parser.cpp
+++ b/src/ishell/parser/expr_parser.cpp
@@ -157,7 +157,7 @@ ExprParser::reducePrimaryRule(const std::vector<StackElm>& rhs) {
             if(auto reg = isa::rf::parseRegister(reg_name)) {
                 return std::make_shared<command::RegisterExpr>(reg_name, *reg);
             } else {
-                throw new ParseException("Invalid Register: " + reg_name);
+                throw ParseException("Invalid Register: " + reg_name);
             }
         } else if(isTokenOfType(rhs[0], TokenType::NUM)) {
             return std::make_shared<command::NumberExpr>(

--- a/src/ishell/parser/parser.cpp
+++ b/src/ishell/parser/parser.cpp
@@ -74,6 +74,9 @@ command::CommandPtr Parser::parse_command(command::CommandContext context) {
     // command otherwise regardless of context if there are events use callback
     if(event_list.empty()) {
         if(context == command::CommandContext::CLI) {
+            common::debug::logln(
+                common::debug::DebugType::PARSER,
+                "Returning a callback from CLI with no events");
             return std::make_shared<command::CallbackCommand>(
                 context,
                 actions,
@@ -81,11 +84,17 @@ command::CommandPtr Parser::parse_command(command::CommandContext context) {
         } else if(
             context == command::CommandContext::REPL &&
             actionsContainWatch(actions.begin(), actions.end())) {
+            common::debug::logln(
+                common::debug::DebugType::PARSER,
+                "Returning a callback from REPL with WATCH command");
             return std::make_shared<command::CallbackCommand>(
                 context,
                 actions,
                 condition);
         } else if(context == command::CommandContext::REPL) {
+            common::debug::logln(
+                common::debug::DebugType::PARSER,
+                "Returning an immediate command from REPL");
             return std::make_shared<command::Command>(
                 context,
                 actions,
@@ -96,6 +105,9 @@ command::CommandPtr Parser::parse_command(command::CommandContext context) {
             throw ParseException("Cannot infer events with unknown context\n");
         }
     } else {
+        common::debug::logln(
+            common::debug::DebugType::PARSER,
+            "Returning a callback with user events");
         return std::make_shared<command::CallbackCommand>(
             context,
             actions,

--- a/src/ishell/repl.cpp
+++ b/src/ishell/repl.cpp
@@ -131,15 +131,10 @@ void Repl::execute() {
                 continue;
             }
             try {
-                auto control =
-                    parser.parse(input, command::CommandContext::REPL);
-                control->setHS(hs);
-                if(auto command =
-                       std::dynamic_pointer_cast<command::Command>(control)) {
-                    command->doit(&std::cout);
-                } else {
-                    std::cerr << "Only COMMANDs are supported at this time\n";
-                }
+                auto c = parser.parse(input, command::CommandContext::REPL);
+                c->setHS(hs);
+                c->install();
+                c->doit(&std::cout);
             } catch(const ishell::parser::ParseException& pe) {
                 std::cerr << "Invalid command\n";
             }

--- a/src/zircon/arguments.cpp
+++ b/src/zircon/arguments.cpp
@@ -416,7 +416,7 @@ void MainArguments::addControllerCallbacks(hart::Hart& hart) {
     for(auto a : parsed_commands) {
         a->setHS(&hart.hs());
         a->setColor(useColor);
-        a->install(&hart);
+        a->install();
     }
 }
 std::vector<std::string> MainArguments::getArgV() { return simulated_argv; }

--- a/src/zircon/main.cpp
+++ b/src/zircon/main.cpp
@@ -32,41 +32,6 @@ int main(int argc, const char** argv, const char** envp) {
             [&stats](hart::HartState& hs) { stats.count(hs); });
     }
 
-    // auto t = std::thread([&hart]() {
-    //     auto parser = ishell::parser::Parser();
-    //     while(1) {
-    //         // hart.hs().waitForExecutionStateChange();
-    //         if(hart.hs().isPaused()) {
-    //             std::cout.flush();
-    //             std::cout << "> ";
-    //             std::string input;
-    //             std::getline(std::cin, input);
-
-    //             try {
-    //                 auto control = parser.parse(input);
-    //                 control->setHS(&hart.hs());
-    //                 if(auto command =
-    //                        std::dynamic_pointer_cast<command::Command>(
-    //                            control)) {
-    //                     command->doit(&std::cout);
-    //                 } else {
-    //                     std::cerr
-    //                         << "Only COMMANDs are supported at this time\n";
-    //                 }
-    //             } catch(const ishell::parser::ParseException& pe) {
-    //                 std::cerr << "Invalid command\n";
-    //             }
-
-    //         } else if(
-    //             hart.hs().getExecutionState() ==
-    //                 hart::ExecutionState::STOPPED ||
-    //             hart.hs().getExecutionState() ==
-    //                 hart::ExecutionState::INVALID_STATE) {
-    //             break;
-    //         }
-    //     }
-    // });
-
     hart.init(args.getArgV(), args.getEnvVars());
     hart.hs().setPC(start);
 
@@ -82,7 +47,6 @@ int main(int argc, const char** argv, const char** envp) {
 
     hart.wait_till_done();
     repl.wait_till_done();
-    // t.join();
 
     if(args.accessRawArguments().get<bool>("--stats")) {
         std::cout << stats.dump() << std::endl;


### PR DESCRIPTION
fixes a number of bugs in ishell

- Dump commands were accidentally defined as Watch type command
- parse exception was thrown as a pointer, not by value

improves
- hartstate now carries a pointer to its owning hart, cleans up some interfaces